### PR TITLE
GH-455 fix license checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0 (May 11, 2022)
+
+BUG FIXES:
+
+* `util.CheckArtifactoryLicense`: Fix only checking for `Enterprise` license type. Now support a list of license types to check.
+
 ## 0.6.0 (May 11, 2022)
 
 NEW FEATURES:

--- a/util/util.go
+++ b/util/util.go
@@ -316,7 +316,7 @@ func AddTelemetry(productId string, resourceMap map[string]*schema.Resource) map
 
 func CheckArtifactoryLicense(client *resty.Client, licenseTypesToCheck ...string) diag.Diagnostics {
 	if len(licenseTypesToCheck) == 0 {
-		return diag.Errorf("missing licenseTypesToCheck")
+		return diag.Errorf("failed: licenseTypesToCheck is empty")
 	}
 
 	type License struct {
@@ -334,7 +334,7 @@ func CheckArtifactoryLicense(client *resty.Client, licenseTypesToCheck ...string
 		Get("/artifactory/api/system/license")
 
 	if err != nil {
-		return fmt.Errorf("Failed to check for license. If your usage doesn't require admin permission, you can set `check_license` attribute to `false` to skip this check. %s", err)
+		return diag.Errorf("Failed to check for license. If your usage doesn't require admin permission, you can set `check_license` attribute to `false` to skip this check. %s", err)
 	}
 
 	var licenseType string
@@ -344,10 +344,10 @@ func CheckArtifactoryLicense(client *resty.Client, licenseTypesToCheck ...string
 		licenseType = licensesWrapper.Type
 	}
 
-	licenseTypesToCheckRegex := fmt.Sprintf("(?:%s)", strings.Join(licenseTypesToCheck, '|'))
+	licenseTypesToCheckRegex := fmt.Sprintf("(?:%s)", strings.Join(licenseTypesToCheck, "|"))
 	if matched, _ := regexp.MatchString(licenseTypesToCheckRegex, licenseType); !matched {
-		licenseTypesToCheckMessage := strings.Join(licenseTypesToCheck, ' or ')
-		return fmt.Errorf("Artifactory requires %s license to work with Terraform! If your usage doesn't require a license, you can set `check_license` attribute to `false` to skip this check.", licenseTypesToCheckMessage)
+		licenseTypesToCheckMessage := strings.Join(licenseTypesToCheck, " or ")
+		return diag.Errorf("Artifactory requires %s license to work with Terraform! If your usage doesn't require a license, you can set `check_license` attribute to `false` to skip this check.", licenseTypesToCheckMessage)
 	}
 
 	return nil


### PR DESCRIPTION
To support https://github.com/jfrog/terraform-provider-artifactory/issues/455

Add license types args to allow checking for any list of license types (vs hardcoded list). Artifactory/Xray checks for 'Enterprise', 'Commercial', and 'Edge', while Project only checks for 'Enterprise'.