### PR TITLE
Use productId from caller for http user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 (July 1, 2022)
+
+REFACTOR:
+
+* Fix client user agent string was hardcoded to Artifactory
+
 ## 1.3.0 (June 14, 2022)
 
 REFACTOR:
@@ -23,7 +29,7 @@ REFACTOR:
 
 REFACTOR:
 
-* `util` package stripped down. Predicates moved to `predicate` packages and packers to `packer` package. 
+* `util` package stripped down. Predicates moved to `predicate` packages and packers to `packer` package.
 * Some remainder of sharable code from artifactory code was moved in.
 * `NoPassword` predicate now no longer also includes `NoClass` - done for distinction and clarity
 

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-func Build(URL, version string) (*resty.Client, error) {
+func Build(URL, productId string) (*resty.Client, error) {
 	u, err := url.ParseRequestURI(URL)
 
 	if err != nil {
@@ -41,7 +41,7 @@ func Build(URL, version string) (*resty.Client, error) {
 		}).
 		SetHeader("content-type", "application/json").
 		SetHeader("accept", "*/*").
-		SetHeader("user-agent", "jfrog/terraform-provider-artifactory:"+version).
+		SetHeader("user-agent", "jfrog/"+productId).
 		SetRetryCount(20)
 
 	restyBase.DisableWarn = true


### PR DESCRIPTION
Caller modules will need to be updated to pass in `productId`