### PR TITLE
Revert project key valiadator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.0 (July 28, 2022)
+
+BUG FIXES:
+
+* Revert changes to size limit for `ProjectKey` validator
+
 ## 1.5.0 (July 27, 2022)
 
 BUG FIXES:

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -51,7 +51,7 @@ var CommaSeperatedList = validation.ToDiagFunc(
 )
 
 var ProjectKey = validation.ToDiagFunc(
-	validation.StringMatch(regexp.MustCompile(`^[a-z0-9]{3,25}$`), "project_key must be 3 - 25 lowercase alphanumeric characters"),
+	validation.StringMatch(regexp.MustCompile(`^[a-z0-9]{3,10}$`), "project_key must be 3 - 10 lowercase alphanumeric characters"),
 )
 
 var validLicenseTypes = []string{


### PR DESCRIPTION
Revert https://github.com/jfrog/terraform-provider-shared/pull/19

`ProjectKey` validator was changed to expand string length limit based on misunderstanding on how it works in the other providers.

There's no change to the size limit handling in Artifactory, thus the change needs to be reverted.