### PR TITLE
Allow project keys to have only 2 characters

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -51,7 +51,7 @@ var CommaSeperatedList = validation.ToDiagFunc(
 )
 
 var ProjectKey = validation.ToDiagFunc(
-	validation.StringMatch(regexp.MustCompile(`^[a-z][a-z0-9\-]{2,9}$`), "project_key must be 3 - 10 lowercase alphanumeric and hyphen characters"),
+	validation.StringMatch(regexp.MustCompile(`^[a-z][a-z0-9\-]{1,9}$`), "project_key must be 2 - 10 lowercase alphanumeric and hyphen characters"),
 )
 
 var validLicenseTypes = []string{

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestProjectKey(t *testing.T) {
 	validProjectKeys := []string{
-		"abc", // min 3
+		"ab", // min 2
 		"abcde12345", // max 10
 		"abc-123", // hyphen is supported but not documented
 		"abc123-", // hyphen can be anywhere
@@ -25,7 +25,7 @@ func TestProjectKey(t *testing.T) {
 
 func TestProjectKey_invalidKeys(t *testing.T) {
 	invalidProjectKeys := []string{
-		"ab", // 2 characters, too short
+		"a", // 1 character, too short
 		"abcdefghijk", // 11 characters, too long
 		"abc,", // invalid characters
 		"-abcde1234", // can't start with hyphen
@@ -40,7 +40,7 @@ func TestProjectKey_invalidKeys(t *testing.T) {
 				t.Errorf("ProjectKey '%s' should fail", projectKey)
 			}
 
-			errorRegex := regexp.MustCompile(`.*project_key must be 3 - 10 lowercase alphanumeric and hyphen characters.*`)
+			errorRegex := regexp.MustCompile(`.*project_key must be 2 - 10 lowercase alphanumeric and hyphen characters.*`)
 			if !errorRegex.MatchString(diag[0].Summary) {
 				t.Fail()
 			}


### PR DESCRIPTION
I'm not sure if this is intended, but my Artifactory instance allowed me to create the following project key:

`sb`

So I guess there either is a bug in the Artifactory API or in this provider. This would fix the provider.