### PR TITLE
Enable resty debug logging based on TF_LOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.22.4 (Apr 4, 2024)
+
+IMPROVEMENTS:
+
+* Enable Resty's debug logging when `TF_LOG` is set to `DEBUG` or `TRACE`.
+
+Issue [#16](https://github.com/jfrog/terraform-provider-shared/issues/16)
+PR: [#58](https://github.com/jfrog/terraform-provider-shared/pull/57)
+
 ## 1.22.3 (Apr 4, 2024)
 
 BUG FIXES:


### PR DESCRIPTION
Close #16 

Also remove the special handling of call home error in `OnAfterResponse` as it doesn't do what we want it to really.