### PR TITLE
Add pre apply config plan check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.29.0 (February 24, 2025)
+
+IMPROVEMENTS:
+
+* Add `PreApply` stage to config plan checks func
+
 ## 1.28.0 (December 20, 2024)
 
 IMPROVEMENTS:


### PR DESCRIPTION
The missing checks for `PreApply` stage is why this checks don't report diff error sometimes in acceptance tests, when the built-in Terraform SDK one does.